### PR TITLE
Upgrade Deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,9 +517,9 @@
       }
     },
     "@tacoinfra/harbinger-lib": {
-      "version": "1.0.23",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.0.23.tgz",
-      "integrity": "sha512-6F/N+J68Bf8ZnedaxNnsPs1lq8lpzQn9oIJGIwLXfrKcCYuYy4JizKZlUYKZoVugXcKWIZ0h8fFer9sLpfvPiw==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.0.26.tgz",
+      "integrity": "sha512-tZvYJhEUz0M+0JZPkWSvT3+iehzsr4zaXBz0jXndnuV2q2AGTiCRnHCR+uIRlCdk93VbrQASv1iYTc1mtBxYLA==",
       "requires": {
         "@lapo/asn1js": "1.1.0",
         "@ledgerhq/hw-transport": "^5.15.0",
@@ -2347,11 +2347,11 @@
       }
     },
     "configstore": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.4.tgz",
+      "integrity": "sha512-0zrqA+vOj4tKAFjho2DjcPby8YNYvU0g2fJLusolvRxpeC3qzfLTrTdPK1/lreiOd2J6prloAR6dcXhcr7mJEw==",
       "requires": {
-        "dot-prop": "^4.1.0",
+        "dot-prop-legacy": "^4.2.1",
         "graceful-fs": "^4.1.2",
         "make-dir": "^1.0.0",
         "unique-string": "^1.0.0",
@@ -2893,10 +2893,10 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
     },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+    "dot-prop-legacy": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop-legacy/-/dot-prop-legacy-4.2.1.tgz",
+      "integrity": "sha512-OpVdloKY3b038o/XJ8zV0b6Uh2VZ/WJhdG2L94YOy+OeFjTZBWxeYfQVx5doIezkWCg7UVTjP2hGQBeSeljTag==",
       "requires": {
         "is-obj": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/tacoinfra/harbinger-signer#readme",
   "dependencies": {
-    "@tacoinfra/harbinger-lib": "^1.0.23",
+    "@tacoinfra/harbinger-lib": "^1.0.26",
     "@types/aws-lambda": "^8.10.61",
     "@types/promise-retry": "^1.1.3",
     "aws-lambda": "^1.0.6",


### PR DESCRIPTION
Fixes an incompatibility in `@tacoinfra/harbinger-lib` and some dependency CVEs by running `npm audit fix`.

Fixes #2. 